### PR TITLE
Merge dev into master

### DIFF
--- a/IvanStoychev.Useful.String.Extensions.Tests/Comparer_Tests.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Comparer_Tests.cs
@@ -98,48 +98,48 @@ public class Comparer_Tests
 
     public static IEnumerable<object[]> Data_Contains_IEnumString_SetComparison_Pass => new[]
             {
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "case", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædia", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archæology", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "case", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædia", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archæology", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.InvariantCulture},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædiA", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædiA", "ARCHÆOLOGY" }), StringComparison.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædiA", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædiA", "ARCHÆOLOGY" }), GlobalVariables.InvariantCultureIgnoreCase},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "case", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædia", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archæology", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.Ordinal},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "case", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædia", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archæology", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.Ordinal},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædiA", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædiA", "ARCHÆOLOGY" }), StringComparison.OrdinalIgnoreCase}
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopædiA", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædiA", "ARCHÆOLOGY" }), GlobalVariables.OrdinalIgnoreCase}
             };
 
     public static IEnumerable<object[]> Data_Contains_IEnumString_SetComparison_Fail => new[]
             {
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, StringComparison.InvariantCulture},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }), StringComparison.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, GlobalVariables.InvariantCulture},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }), GlobalVariables.InvariantCulture},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Kase", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHAEOLOGY", "dummy" }, StringComparison.InvariantCultureIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Kase", "encyclopaedia", "ARCHAEOLOGY" }), StringComparison.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Kase", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHAEOLOGY", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Kase", "encyclopaedia", "ARCHAEOLOGY" }), GlobalVariables.InvariantCultureIgnoreCase},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, StringComparison.Ordinal},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }), StringComparison.Ordinal},
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Case", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "ARCHÆOLOGY", "dummy" }, GlobalVariables.Ordinal},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }), GlobalVariables.Ordinal},
 
-                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Kase", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archaeology", "dummy" }, StringComparison.OrdinalIgnoreCase},
-                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Kase", "encyclopaedia", "Archaeology" }), StringComparison.OrdinalIgnoreCase}
+                new object[] { "case encyclopædia Archæology", new string[] { "dummy", "Kase", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new List<string>() { "dummy", "encyclopaedia", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new HashSet<string>() { "dummy", "Archaeology", "dummy" }, GlobalVariables.OrdinalIgnoreCase},
+                new object[] { "case encyclopædia Archæology", new Queue<string>(new string[] { "Kase", "encyclopaedia", "Archaeology" }), GlobalVariables.OrdinalIgnoreCase}
             };
 
     public static IEnumerable<object[]> Data_Contains_IEnumChar_DefaultComparison_Pass => new[]
@@ -158,50 +158,52 @@ public class Comparer_Tests
                 new object[] { "char", new Queue<char>(new char[] { 'z', 'z', 'z', 'R' }) }
             };
 
+    // The comments denote what is the code for the character preceding them as visually they are very similar.
     public static IEnumerable<object[]> Data_Contains_IEnumChar_SetComparison_Pass => new[]
             {
-                new object[] { "i" /* (U+0069) */, new char[] { 'i' /* (U+0069) */, 'z', 'z', 'z' }, StringComparison.InvariantCulture },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'i' /* (U+0069) */, 'z', 'z' }, StringComparison.InvariantCulture },
-                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'i' /* (U+0069) */, 'z' }, StringComparison.InvariantCulture },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'i' /* (U+0069) */ }), StringComparison.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new char[] { 'i' /* (U+0069) */, 'z', 'z', 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'i' /* (U+0069) */, 'z', 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'i' /* (U+0069) */, 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'i' /* (U+0069) */ }), GlobalVariables.InvariantCulture },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'I' /* (U+0049) */, 'z', 'z', 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'I' /* (U+0049) */, 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new char[] { 'I' /* (U+0049) */, 'z', 'z', 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'I' /* (U+0049) */, 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'i' /* (U+0069) */, 'z', 'z', 'z' }, StringComparison.Ordinal },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'i' /* (U+0069) */, 'z', 'z' }, StringComparison.Ordinal },
-                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'i' /* (U+0069) */, 'z' }, StringComparison.Ordinal },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'i' /* (U+0069) */ }), StringComparison.Ordinal },
+                new object[] { "i" /* (U+0069) */, new char[] { 'i' /* (U+0069) */, 'z', 'z', 'z' }, GlobalVariables.Ordinal },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'i' /* (U+0069) */, 'z', 'z' }, GlobalVariables.Ordinal },
+                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'i' /* (U+0069) */, 'z' }, GlobalVariables.Ordinal },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'i' /* (U+0069) */ }), GlobalVariables.Ordinal },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'I' /* (U+0049) */, 'z', 'z', 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'I' /* (U+0049) */, 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), StringComparison.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new char[] { 'I' /* (U+0049) */, 'z', 'z', 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new HashSet<char>() { 'z', 'z', 'I' /* (U+0049) */, 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), GlobalVariables.OrdinalIgnoreCase },
             };
 
+    // The comments denote what is the code for the character preceding them as visually they are very similar.
     public static IEnumerable<object[]> Data_Contains_IEnumChar_SetComparison_Fail => new[]
             {
-                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, StringComparison.InvariantCulture },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, StringComparison.InvariantCulture },
-                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, StringComparison.InvariantCulture },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), StringComparison.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, GlobalVariables.InvariantCulture },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), GlobalVariables.InvariantCulture },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'ı' /* (U+0131) */, 'z', 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "i" /* (U+0049) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'ı' /* (U+0131) */ }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'ı' /* (U+0131) */, 'z', 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "i" /* (U+0049) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'ı' /* (U+0131) */ }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, StringComparison.Ordinal },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, StringComparison.Ordinal },
-                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, StringComparison.Ordinal },
-                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), StringComparison.Ordinal },
+                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, GlobalVariables.Ordinal },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'I' /* (U+0049) */, 'z', 'z' }, GlobalVariables.Ordinal },
+                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, GlobalVariables.Ordinal },
+                new object[] { "i" /* (U+0069) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'I' /* (U+0049) */ }), GlobalVariables.Ordinal },
 
-                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'ı' /* (U+0131) */, 'z', 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "I" /* (U+0049) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'ı' /* (U+0131) */ }), StringComparison.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new char[] { 'ı' /* (U+0131) */, 'z', 'z', 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "i" /* (U+0069) */, new List<char>() { 'z', 'ı' /* (U+0131) */, 'z', 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "I" /* (U+0049) */, new HashSet<char>() { 'z', 'z', 'ı' /* (U+0131) */, 'z' }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "I" /* (U+0049) */, new Queue<char>(new char[] { 'z', 'z', 'z', 'ı' /* (U+0131) */ }), GlobalVariables.OrdinalIgnoreCase },
             };
 
     #endregion IEnumerable test data

--- a/IvanStoychev.Useful.String.Extensions.Tests/Comparer_Tests_Exceptions.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Comparer_Tests_Exceptions.cs
@@ -54,12 +54,12 @@ public class Comparer_Tests_Exceptions
 
     public static IEnumerable<object[]> Data_StringComparison_AllValues => new[]
             {
-                new object[] { StringComparison.CurrentCulture },
-                new object[] { StringComparison.CurrentCultureIgnoreCase },
-                new object[] { StringComparison.InvariantCulture },
-                new object[] { StringComparison.InvariantCultureIgnoreCase },
-                new object[] { StringComparison.Ordinal },
-                new object[] { StringComparison.OrdinalIgnoreCase }
+                new object[] { GlobalVariables.CurrentCulture },
+                new object[] { GlobalVariables.CurrentCultureIgnoreCase },
+                new object[] { GlobalVariables.InvariantCulture },
+                new object[] { GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { GlobalVariables.Ordinal },
+                new object[] { GlobalVariables.OrdinalIgnoreCase }
             };
 
     #endregion IEnumerable test data

--- a/IvanStoychev.Useful.String.Extensions.Tests/GlobalVariables.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/GlobalVariables.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace IvanStoychev.Useful.String.Extensions.Tests;
+
+class GlobalVariables
+{
+    internal static StringComparison CurrentCulture = StringComparison.CurrentCulture;
+    internal static StringComparison CurrentCultureIgnoreCase = StringComparison.CurrentCultureIgnoreCase;
+    internal static StringComparison InvariantCulture = StringComparison.InvariantCulture;
+    internal static StringComparison InvariantCultureIgnoreCase = StringComparison.InvariantCultureIgnoreCase;
+    internal static StringComparison Ordinal = StringComparison.Ordinal;
+    internal static StringComparison OrdinalIgnoreCase = StringComparison.OrdinalIgnoreCase;
+}

--- a/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests.cs
@@ -1115,25 +1115,25 @@ public class Remover_Tests
 
     public static IEnumerable<object[]> Data_Remove_IEnumString_SetComparison_Pass => new[]
             {
-                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopædia", "ARCHÆOLOGY" }, StringComparison.InvariantCulture, "Case  Archæology" },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "Case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.InvariantCulture, " encyclopædia Archæology" },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "Archæology" }, StringComparison.InvariantCulture, "Case encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædia", "Archæology" }), StringComparison.InvariantCulture, "  " },
+                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopædia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCulture, "Case  Archæology" },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "Case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCulture, " encyclopædia Archæology" },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "Archæology" }, GlobalVariables.InvariantCulture, "Case encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "Case", "encyclopædia", "Archæology" }), GlobalVariables.InvariantCulture, "  " },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopaedia", "ARCHAEOLOGY" }, StringComparison.InvariantCultureIgnoreCase, " encyclopædia Archæology" },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "kase", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.InvariantCultureIgnoreCase, "Case encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "kase", "ENCYCLOPÆDIA", "ARCHAEOLOGY" }, StringComparison.InvariantCultureIgnoreCase, "Case  Archæology" },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "ENCYCLOPÆDIA", "ARCHÆOLOGY" }), StringComparison.InvariantCultureIgnoreCase, "  " },
+                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopaedia", "ARCHAEOLOGY" }, GlobalVariables.InvariantCultureIgnoreCase, " encyclopædia Archæology" },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "kase", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCultureIgnoreCase, "Case encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "kase", "ENCYCLOPÆDIA", "ARCHAEOLOGY" }, GlobalVariables.InvariantCultureIgnoreCase, "Case  Archæology" },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "ENCYCLOPÆDIA", "ARCHÆOLOGY" }), GlobalVariables.InvariantCultureIgnoreCase, "  " },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.Ordinal, " encyclopædia Archæology" },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "case", "encyclopædia", "ARCHÆOLOGY" }, StringComparison.Ordinal, "Case  Archæology" },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "Archæology" }, StringComparison.Ordinal, "Case encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.Ordinal, "Case  " },
+                new object[] { "Case encyclopædia Archæology", new string[] { "Case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.Ordinal, " encyclopædia Archæology" },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "case", "encyclopædia", "ARCHÆOLOGY" }, GlobalVariables.Ordinal, "Case  Archæology" },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "Archæology" }, GlobalVariables.Ordinal, "Case encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.Ordinal, "Case  " },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.OrdinalIgnoreCase, " encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.OrdinalIgnoreCase, " encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.OrdinalIgnoreCase, " encyclopædia " },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }), StringComparison.OrdinalIgnoreCase, " encyclopædia " }
+                new object[] { "Case encyclopædia Archæology", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.OrdinalIgnoreCase, " encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.OrdinalIgnoreCase, " encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.OrdinalIgnoreCase, " encyclopædia " },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }), GlobalVariables.OrdinalIgnoreCase, " encyclopædia " }
             };
 
     public static IEnumerable<object[]> Data_Remove_IEnumString_DefaultComparison_Fail => new[]
@@ -1146,24 +1146,24 @@ public class Remover_Tests
 
     public static IEnumerable<object[]> Data_Remove_IEnumString_SetComparison_Fail => new[]
             {
-                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, StringComparison.InvariantCulture },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, StringComparison.InvariantCulture },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, StringComparison.InvariantCulture },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), StringComparison.InvariantCulture },
+                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCulture },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCulture },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCulture },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), GlobalVariables.InvariantCulture },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, StringComparison.Ordinal },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, StringComparison.Ordinal },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, StringComparison.Ordinal },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), StringComparison.Ordinal },
+                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, GlobalVariables.Ordinal },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.Ordinal },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.Ordinal },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), GlobalVariables.Ordinal },
 
-                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), StringComparison.OrdinalIgnoreCase }
+                new object[] { "Case encyclopædia Archæology", new string[] { "dummy", "dummy", "dummy" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new List<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new HashSet<string>() { "dummy", "dummy", "dummy" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { "Case encyclopædia Archæology", new Queue<string>(new string[] { "dummy", "dummy", "dummy" }), GlobalVariables.OrdinalIgnoreCase }
             };
 }

--- a/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests.cs
@@ -302,7 +302,7 @@ public class Remover_Tests
     #region Data
 
 	[Theory]
-    [InlineData("RemoveMeRemoveMe text RemoveMeRemoveMe", "RemoveMe", " text ")]
+    [InlineData("RemoveMe removeMe text removeMe RemoveMe", "RemoveMe", " removeMe text removeMe ")]
     [InlineData("RemoveMeRemoveMe text Removeme", "RemoveMe", " text Removeme")]
     [InlineData("removeme text RemoveMeRemoveMe", "RemoveMe", "removeme text ")]
     
@@ -317,12 +317,12 @@ public class Remover_Tests
     #region Data
 
 	[Theory]
-    [InlineData("RemoveMeRemoveMe text RemoveMeRemoveMe", "RemoveMe", " text ")]
+    [InlineData("RemoveMe removeMe text removeMe RemoveMe", "RemoveMe", " removeMe text removeMe ")]
     [InlineData("RemoveMeRemoveMe text Removeme", "RemoveMe", " text Removeme")]
     [InlineData("removeme text RemoveMeRemoveMe", "RemoveMe", "removeme text ")]
-    
-	#endregion Data
-	public void Trim_CultureInfo_ConsiderCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+
+    #endregion Data
+    public void Trim_CultureInfo_ConsiderCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.Trim(stringToRemove, false, CultureInfo.InvariantCulture, false);
 
@@ -332,7 +332,7 @@ public class Remover_Tests
     #region Data
 
 	[Theory]
-    [InlineData("RemoveMeRemoveMe text RemoveMeRemoveMe", "RemoveMe", "text")]
+    [InlineData("RemoveMe removeMe text removeMe RemoveMe", "RemoveMe", "removeMe text removeMe")]
     [InlineData("RemoveMeRemoveMe text Removeme", "RemoveMe", "text Removeme")]
     [InlineData("removeme text RemoveMeRemoveMe", "RemoveMe", "removeme text")]
 
@@ -513,16 +513,16 @@ public class Remover_Tests
     #region Data
 
 	[Theory]
-    [InlineData(" RemoveMe text RemoveMe", "dummy", "RemoveMe text RemoveMe")]
-    [InlineData("RemoveMe text ", "", "RemoveMe text")]
-    [InlineData(" text RemoveMe ", null, "text RemoveMe")]
-    
-	#endregion Data
-	public void Trim_CultureInfo_ConsiderCase_TrimWhitespace_Fail(string testString, string stringToRemove, string expectedString)
+    [InlineData("RemoveMe text RemoveMe", "dummy")]
+    [InlineData("RemoveMe text", "")]
+    [InlineData("text RemoveMe", null)]
+
+    #endregion Data
+    public void Trim_CultureInfo_ConsiderCase_TrimWhitespace_Fail(string testString, string stringToRemove)
     {
         string actual = testString.Trim(stringToRemove, false, CultureInfo.InvariantCulture, true);
 
-        Assert.Equal(expectedString, actual);
+        Assert.Equal(testString, actual);
     }
 
     #endregion Fail
@@ -635,12 +635,12 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData("encyclopædiaencyclopædia Case Archæology ", "encyclopædia", " Case Archæology ")]
-    [InlineData("Case encyclopædia Archæology", "Case", " encyclopædia Archæology")]
-    [InlineData("Archæology Archæology encyclopædia Case ", "Archæology ", "encyclopædia Case ")]
+    [InlineData("encyclopædiaencyclopædia Case Archæology ", "EncycLopædia", " Case Archæology ")]
+    [InlineData("Case encyclopædia Archæology", "casE", " encyclopædia Archæology")]
+    [InlineData("Archæology Archæology encyclopædia Case ", "archæoLOgy ", "encyclopædia Case ")]
 
     #endregion Data
-    public void TrimStart_CultureInfo_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimStart_CultureInfo_IgnoreCase_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture);
 
@@ -650,12 +650,12 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData("encyclopædiaencyclopædia Case Archæology ", "encyclopædia", " Case Archæology ")]
-    [InlineData("Case encyclopædia Archæology", "Case", " encyclopædia Archæology")]
-    [InlineData("Archæology Archæology encyclopædia Case ", "Archæology ", "encyclopædia Case ")]
+    [InlineData("encyclopædiaencyclopædia Case Archæology ", "EncyclOpædia", " Case Archæology ")]
+    [InlineData("Case encyclopædia Archæology", "cAse", " encyclopædia Archæology")]
+    [InlineData("Archæology Archæology encyclopædia Case ", "archæoloGy ", "encyclopædia Case ")]
 
     #endregion Data
-    public void TrimStart_CultureInfo_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimStart_CultureInfo_IgnoreCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture, false);
 
@@ -665,20 +665,65 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData("encyclopædiaencyclopædia Case Archæology ", "encyclopædia", "Case Archæology ")]
-    [InlineData("Case encyclopædia Archæology", "Case", "encyclopædia Archæology")]
-    [InlineData("Archæology Archæology encyclopædia Case ", "Archæology ", "encyclopædia Case ")]
+    [InlineData("encyclopædiaencyclopædia Case Archæology ", "enCYclopædia", "Case Archæology ")]
+    [InlineData("Case encyclopædia Archæology", "caSe", "encyclopædia Archæology")]
+    [InlineData("Archæology Archæology encyclopædia Case ", "aRchæolOgy ", "encyclopædia Case ")]
 
     #endregion Data
-    public void TrimStart_CultureInfo_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimStart_CultureInfo_IgnoreCase_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture, true);
 
         Assert.Equal(expectedString, actual);
     }
 
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædiaEncyclopædia Case Archæology ", "encyclopædia", "Encyclopædia Case Archæology ")]
+    [InlineData("Case case encyclopædia Archæology", "Case", " case encyclopædia Archæology")]
+    [InlineData("Archæology archæology encyclopædia Case ", "Archæology ", "archæology encyclopædia Case ")]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture);
+
+        Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædiaEncyclopædia Case Archæology ", "encyclopædia", "Encyclopædia Case Archæology ")]
+    [InlineData("Case case encyclopædia Archæology", "Case", " case encyclopædia Archæology")]
+    [InlineData("Archæology archæology encyclopædia Case ", "Archæology ", "archæology encyclopædia Case ")]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture, false);
+
+        Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædiaEncyclopædia Case Archæology ", "encyclopædia", "Encyclopædia Case Archæology ")]
+    [InlineData("Case case encyclopædia Archæology", "Case", "case encyclopædia Archæology")]
+    [InlineData("Archæology archæology encyclopædia Case ", "Archæology", "archæology encyclopædia Case ")]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture, true);
+
+        Assert.Equal(expectedString, actual);
+    }
+
     #endregion Pass
-    
+
     #region Fail
 
     #region Data
@@ -776,7 +821,7 @@ public class Remover_Tests
     [InlineData(" Archæology encyclopædia Case ", null)]
 
     #endregion Data
-    public void TrimStart_CultureInfo_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
+    public void TrimStart_CultureInfo_IgnoreCase_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture);
 
@@ -791,7 +836,7 @@ public class Remover_Tests
     [InlineData(" Archæology encyclopædia Case ", null)]
 
     #endregion Data
-    public void TrimStart_CultureInfo_DontTrimWhitespace_Fail(string testString, string stringToRemove)
+    public void TrimStart_CultureInfo_IgnoreCase_DontTrimWhitespace_Fail(string testString, string stringToRemove)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture, false);
 
@@ -806,9 +851,54 @@ public class Remover_Tests
     [InlineData("Archæology encyclopædia Case ", null)]
 
     #endregion Data
-    public void TrimStart_CultureInfo_TrimWhitespace_Fail(string testString, string stringToRemove)
+    public void TrimStart_CultureInfo_IgnoreCase_TrimWhitespace_Fail(string testString, string stringToRemove)
     {
         string actual = testString.TrimStart(stringToRemove, true, CultureInfo.InvariantCulture, true);
+
+        Assert.Equal(testString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology ", "dummy")]
+    [InlineData(" Case encyclopædia Archæology", "")]
+    [InlineData(" Archæology encyclopædia Case ", null)]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture);
+
+        Assert.Equal(testString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology ", "dummy")]
+    [InlineData(" Case encyclopædia Archæology", "")]
+    [InlineData(" Archæology encyclopædia Case ", null)]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_DontTrimWhitespace_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture, false);
+
+        Assert.Equal(testString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology ", "dummy")]
+    [InlineData("Case encyclopædia Archæology", "")]
+    [InlineData("Archæology encyclopædia Case ", null)]
+
+    #endregion Data
+    public void TrimStart_CultureInfo_ConsiderCase_TrimWhitespace_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimStart(stringToRemove, false, CultureInfo.InvariantCulture, true);
 
         Assert.Equal(testString, actual);
     }
@@ -923,12 +1013,12 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData(" encyclopædia Case ArchæologyArchæology", "Archæology", " encyclopædia Case ")]
-    [InlineData("encyclopædia Archæology Case Case", " Case", "encyclopædia Archæology")]
-    [InlineData(" Archæology Case encyclopædia", "encyclopædia", " Archæology Case ")]
+    [InlineData(" encyclopædia Case ArchæologyArchæology", "archæology", " encyclopædia Case ")]
+    [InlineData("encyclopædia Archæology Case Case", " case", "encyclopædia Archæology")]
+    [InlineData(" Archæology Case encyclopædia", "Encyclopædia", " Archæology Case ")]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimEnd_CultureInfo_IgnoreCase_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture);
 
@@ -938,12 +1028,12 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData(" encyclopædia Case ArchæologyArchæology", "Archæology", " encyclopædia Case ")]
-    [InlineData("encyclopædia Archæology Case Case", " Case", "encyclopædia Archæology")]
-    [InlineData(" Archæology Case encyclopædia", "encyclopædia", " Archæology Case ")]
+    [InlineData(" encyclopædia Case ArchæologyArchæology", "archæology", " encyclopædia Case ")]
+    [InlineData("encyclopædia Archæology Case Case", " case", "encyclopædia Archæology")]
+    [InlineData(" Archæology Case encyclopædia", "Encyclopædia", " Archæology Case ")]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimEnd_CultureInfo_IgnoreCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture, false);
 
@@ -953,14 +1043,59 @@ public class Remover_Tests
     #region Data
 
     [Theory]
-    [InlineData(" encyclopædia Case ArchæologyArchæology", "Archæology", " encyclopædia Case")]
-    [InlineData("encyclopædia Archæology Case Case", " Case", "encyclopædia Archæology")]
-    [InlineData(" Archæology Case encyclopædia", "encyclopædia", " Archæology Case")]
+    [InlineData(" encyclopædia Case ArchæologyArchæology", "archæology", " encyclopædia Case")]
+    [InlineData("encyclopædia Archæology Case Case", " case", "encyclopædia Archæology")]
+    [InlineData(" Archæology Case encyclopædia", "Encyclopædia", " Archæology Case")]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    public void TrimEnd_CultureInfo_IgnoreCase_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture, true);
+
+        Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData(" encyclopædia Case archæologyArchæology", "Archæology", " encyclopædia Case archæology")]
+    [InlineData("encyclopædia Archæology case  Case", " Case", "encyclopædia Archæology case ")]
+    [InlineData(" Archæology Case Encyclopædia encyclopædia", "encyclopædia", " Archæology Case Encyclopædia ")]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_DefaultWhitespaceTrim_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture);
+
+        Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData(" encyclopædia Case archæologyArchæology", "Archæology", " encyclopædia Case archæology")]
+    [InlineData("encyclopædia Archæology case  Case", " Case", "encyclopædia Archæology case ")]
+    [InlineData(" Archæology Case Encyclopædia encyclopædia", "encyclopædia", " Archæology Case Encyclopædia ")]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_DontTrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture, false);
+
+        Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData(" encyclopædia Case archæologyArchæology", "Archæology", " encyclopædia Case archæology")]
+    [InlineData("encyclopædia Archæology case  Case", " Case", "encyclopædia Archæology case")]
+    [InlineData(" Archæology Case Encyclopædia encyclopædia", "encyclopædia", " Archæology Case Encyclopædia")]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_TrimWhitespace_Pass(string testString, string stringToRemove, string expectedString)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture, true);
 
         Assert.Equal(expectedString, actual);
     }
@@ -1064,7 +1199,7 @@ public class Remover_Tests
     [InlineData(" Archæology encyclopædia Case ", null)]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
+    public void TrimEnd_CultureInfo_IgnoreCase_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture);
 
@@ -1079,7 +1214,7 @@ public class Remover_Tests
     [InlineData(" Archæology encyclopædia Case ", null)]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_DontTrimWhitespace_Fail(string testString, string stringToRemove)
+    public void TrimEnd_CultureInfo_IgnoreCase_DontTrimWhitespace_Fail(string testString, string stringToRemove)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture, false);
 
@@ -1094,11 +1229,56 @@ public class Remover_Tests
     [InlineData(" Archæology encyclopædia Case ", null, " Archæology encyclopædia Case")]
 
     #endregion Data
-    public void TrimEnd_CultureInfo_TrimWhitespace_Fail(string testString, string stringToRemove, string expectedString)
+    public void TrimEnd_CultureInfo_IgnoreCase_TrimWhitespace_Fail(string testString, string stringToRemove, string expectedString)
     {
         string actual = testString.TrimEnd(stringToRemove, true, CultureInfo.InvariantCulture, true);
 
         Assert.Equal(expectedString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology ", "dummy")]
+    [InlineData(" Case encyclopædia Archæology", "")]
+    [InlineData(" Archæology encyclopædia Case ", null)]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_DefaultWhitespaceTrim_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture);
+
+        Assert.Equal(testString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology ", "dummy")]
+    [InlineData(" Case encyclopædia Archæology", "")]
+    [InlineData(" Archæology encyclopædia Case ", null)]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_DontTrimWhitespace_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture, false);
+
+        Assert.Equal(testString, actual);
+    }
+
+    #region Data
+
+    [Theory]
+    [InlineData("encyclopædia Case Archæology", "dummy")]
+    [InlineData(" Case encyclopædia Archæology", "")]
+    [InlineData(" Archæology encyclopædia Case", null)]
+
+    #endregion Data
+    public void TrimEnd_CultureInfo_ConsiderCase_TrimWhitespace_Fail(string testString, string stringToRemove)
+    {
+        string actual = testString.TrimEnd(stringToRemove, false, CultureInfo.InvariantCulture, true);
+
+        Assert.Equal(testString, actual);
     }
 
     #endregion Fail

--- a/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests_Exceptions.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Remover_Tests_Exceptions.cs
@@ -198,79 +198,79 @@ public class Remover_Tests_Exceptions
 
     public static IEnumerable<object[]> Data_Remove_SetComparison_NullArgument => new[]
             {
-                new object[] { StringComparison.InvariantCulture },
-                new object[] { StringComparison.InvariantCultureIgnoreCase },
-                new object[] { StringComparison.Ordinal },
-                new object[] { StringComparison.OrdinalIgnoreCase }
+                new object[] { GlobalVariables.InvariantCulture },
+                new object[] { GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { GlobalVariables.Ordinal },
+                new object[] { GlobalVariables.OrdinalIgnoreCase }
             };
 
     public static IEnumerable<object[]> Data_Remove_SetComparison_IEnumEmpty => new[]
             {
-                new object[] { new string[] {  }, StringComparison.InvariantCulture },
-                new object[] { new List<string>(), StringComparison.InvariantCulture },
-                new object[] { new HashSet<string>() {  }, StringComparison.InvariantCulture },
-                new object[] { new Queue<string>(new string[] {  }), StringComparison.InvariantCulture },
+                new object[] { new string[] {  }, GlobalVariables.InvariantCulture },
+                new object[] { new List<string>(), GlobalVariables.InvariantCulture },
+                new object[] { new HashSet<string>() {  }, GlobalVariables.InvariantCulture },
+                new object[] { new Queue<string>(new string[] {  }), GlobalVariables.InvariantCulture },
 
-                new object[] { new string[] {  }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new List<string>() {  }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new HashSet<string>() {  }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new Queue<string>(new string[] {  }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { new string[] {  }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new List<string>() {  }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new HashSet<string>() {  }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new Queue<string>(new string[] {  }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { new string[] {  }, StringComparison.Ordinal },
-                new object[] { new List<string>() {  }, StringComparison.Ordinal },
-                new object[] { new HashSet<string>() {  }, StringComparison.Ordinal },
-                new object[] { new Queue<string>(new string[] {  }), StringComparison.Ordinal },
+                new object[] { new string[] {  }, GlobalVariables.Ordinal },
+                new object[] { new List<string>() {  }, GlobalVariables.Ordinal },
+                new object[] { new HashSet<string>() {  }, GlobalVariables.Ordinal },
+                new object[] { new Queue<string>(new string[] {  }), GlobalVariables.Ordinal },
 
-                new object[] { new string[] {  }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new List<string>() {  }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new HashSet<string>() {  }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new Queue<string>(new string[] {  }), StringComparison.OrdinalIgnoreCase }
+                new object[] { new string[] {  }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new List<string>() {  }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new HashSet<string>() {  }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new Queue<string>(new string[] {  }), GlobalVariables.OrdinalIgnoreCase }
             };
 
     public static IEnumerable<object[]> Data_Remove_SetComparison_NullMember => new[]
             {
-                new object[] { new string[] { null, "asd", "asd", "asd" }, StringComparison.InvariantCulture },
-                new object[] { new List<string>() { "asd", null, "asd", "asd" }, StringComparison.InvariantCulture },
-                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, StringComparison.InvariantCulture },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), StringComparison.InvariantCulture },
+                new object[] { new string[] { null, "asd", "asd", "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new List<string>() { "asd", null, "asd", "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), GlobalVariables.InvariantCulture },
 
-                new object[] { new string[] { null, "asd", "asd", "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new List<string>() { "asd", null, "asd", "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { new string[] { null, "asd", "asd", "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new List<string>() { "asd", null, "asd", "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { new string[] { null, "asd", "asd", "asd" }, StringComparison.Ordinal },
-                new object[] { new List<string>() { "asd", null, "asd", "asd" }, StringComparison.Ordinal },
-                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, StringComparison.Ordinal },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), StringComparison.Ordinal },
+                new object[] { new string[] { null, "asd", "asd", "asd" }, GlobalVariables.Ordinal },
+                new object[] { new List<string>() { "asd", null, "asd", "asd" }, GlobalVariables.Ordinal },
+                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, GlobalVariables.Ordinal },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), GlobalVariables.Ordinal },
 
-                new object[] { new string[] { null, "asd", "asd", "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new List<string>() { "asd", null, "asd", "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), StringComparison.OrdinalIgnoreCase }
+                new object[] { new string[] { null, "asd", "asd", "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new List<string>() { "asd", null, "asd", "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new HashSet<string>() { "asd", "asd", null, "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", null }), GlobalVariables.OrdinalIgnoreCase }
             };
 
     public static IEnumerable<object[]> Data_Remove_SetComparison_EmptyStringMember => new[]
             {
-                new object[] { new string[] { "", "asd", "asd", "asd" }, StringComparison.InvariantCulture },
-                new object[] { new List<string>() { "asd", "", "asd", "asd" }, StringComparison.InvariantCulture },
-                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, StringComparison.InvariantCulture },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), StringComparison.InvariantCulture },
+                new object[] { new string[] { "", "asd", "asd", "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new List<string>() { "asd", "", "asd", "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, GlobalVariables.InvariantCulture },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), GlobalVariables.InvariantCulture },
 
-                new object[] { new string[] { "", "asd", "asd", "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new List<string>() { "asd", "", "asd", "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, StringComparison.InvariantCultureIgnoreCase },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), StringComparison.InvariantCultureIgnoreCase },
+                new object[] { new string[] { "", "asd", "asd", "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new List<string>() { "asd", "", "asd", "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, GlobalVariables.InvariantCultureIgnoreCase },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), GlobalVariables.InvariantCultureIgnoreCase },
 
-                new object[] { new string[] { "", "asd", "asd", "asd" }, StringComparison.Ordinal },
-                new object[] { new List<string>() { "asd", "", "asd", "asd" }, StringComparison.Ordinal },
-                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, StringComparison.Ordinal },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), StringComparison.Ordinal },
+                new object[] { new string[] { "", "asd", "asd", "asd" }, GlobalVariables.Ordinal },
+                new object[] { new List<string>() { "asd", "", "asd", "asd" }, GlobalVariables.Ordinal },
+                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, GlobalVariables.Ordinal },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), GlobalVariables.Ordinal },
 
-                new object[] { new string[] { "", "asd", "asd", "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new List<string>() { "asd", "", "asd", "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, StringComparison.OrdinalIgnoreCase },
-                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), StringComparison.OrdinalIgnoreCase }
+                new object[] { new string[] { "", "asd", "asd", "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new List<string>() { "asd", "", "asd", "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new HashSet<string>() { "asd", "asd", "", "asd" }, GlobalVariables.OrdinalIgnoreCase },
+                new object[] { new Queue<string>(new string[] { "asd", "asd", "asd", "" }), GlobalVariables.OrdinalIgnoreCase }
             };
 
     #endregion Data

--- a/IvanStoychev.Useful.String.Extensions.Tests/Replacer_Tests.cs
+++ b/IvanStoychev.Useful.String.Extensions.Tests/Replacer_Tests.cs
@@ -32,24 +32,24 @@ public class Replacer_Tests
 
     public static IEnumerable<object[]> Data_Replace_SetComparison_Pass => new[]
             {
-                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.InvariantCulture, "newWord encyclopædia Archæology" },
-                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, StringComparison.InvariantCulture, "case newWord Archæology" },
-                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, StringComparison.InvariantCulture, "case encyclopædia newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.InvariantCulture, "newWord newWord newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCulture, "newWord encyclopædia Archæology" },
+                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCulture, "case newWord Archæology" },
+                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, GlobalVariables.InvariantCulture, "case encyclopædia newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.InvariantCulture, "newWord newWord newWord" },
 
-                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.InvariantCultureIgnoreCase, "newWord encyclopædia newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, StringComparison.InvariantCultureIgnoreCase, "newWord newWord newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, StringComparison.InvariantCultureIgnoreCase, "newWord encyclopædia newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.InvariantCultureIgnoreCase, "newWord newWord newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCultureIgnoreCase, "newWord encyclopædia newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, GlobalVariables.InvariantCultureIgnoreCase, "newWord newWord newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, GlobalVariables.InvariantCultureIgnoreCase, "newWord encyclopædia newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.InvariantCultureIgnoreCase, "newWord newWord newWord" },
 
-                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.Ordinal, "newWord encyclopædia Archæology" },
-                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, StringComparison.Ordinal, "case newWord Archæology" },
-                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, StringComparison.Ordinal, "case encyclopædia newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.Ordinal, "newWord newWord newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "case", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.Ordinal, "newWord encyclopædia Archæology" },
+                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHÆOLOGY" }, GlobalVariables.Ordinal, "case newWord Archæology" },
+                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "Case", "encyclopaedia", "Archæology" }, GlobalVariables.Ordinal, "case encyclopædia newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.Ordinal, "newWord newWord newWord" },
 
-                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "kase", "encyclopaedia", "ARCHÆOLOGY" }, StringComparison.OrdinalIgnoreCase, "case encyclopædia newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHAEOLOGY" }, StringComparison.OrdinalIgnoreCase, "newWord newWord Archæology" },
-                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "kase", "encyclopædia", "Archæology" }, StringComparison.OrdinalIgnoreCase, "case newWord newWord" },
-                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), StringComparison.OrdinalIgnoreCase, "newWord newWord newWord" }
+                new object[] { "case encyclopædia Archæology", "newWord", new string[] { "kase", "encyclopaedia", "ARCHÆOLOGY" }, GlobalVariables.OrdinalIgnoreCase, "case encyclopædia newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new List<string>() { "Case", "encyclopædia", "ARCHAEOLOGY" }, GlobalVariables.OrdinalIgnoreCase, "newWord newWord Archæology" },
+                new object[] { "case encyclopædia Archæology", "newWord", new HashSet<string>() { "kase", "encyclopædia", "Archæology" }, GlobalVariables.OrdinalIgnoreCase, "case newWord newWord" },
+                new object[] { "case encyclopædia Archæology", "newWord", new Queue<string>(new string[] { "case", "encyclopædia", "Archæology" }), GlobalVariables.OrdinalIgnoreCase, "newWord newWord newWord" }
             };
 }

--- a/IvanStoychev.Useful.String.Extensions/Comparer.cs
+++ b/IvanStoychev.Useful.String.Extensions/Comparer.cs
@@ -7,7 +7,7 @@ namespace IvanStoychev.Useful.String.Extensions;
 /// <summary>
 /// Contains methods for determining if a substring is contained in another string.
 /// </summary>
-public static class Comparer
+public static partial class StringExtensions
 {
     /// <summary>
     /// Returns a <see langword="bool"/> indicating whether any of the strings in <paramref name="keywords"/> occur in this string, using the specified comparison rules.

--- a/IvanStoychev.Useful.String.Extensions/IvanStoychev.Useful.String.Extensions.csproj
+++ b/IvanStoychev.Useful.String.Extensions/IvanStoychev.Useful.String.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Authors>Ivan Stoychev</Authors>
     <Title>Ivan Stoychev's Useful String Extensions</Title>
     <Language>English</Language>

--- a/IvanStoychev.Useful.String.Extensions/Keeper.cs
+++ b/IvanStoychev.Useful.String.Extensions/Keeper.cs
@@ -7,7 +7,7 @@ namespace IvanStoychev.Useful.String.Extensions;
 /// <summary>
 /// Contains methods that remove all but a specified set of characters from a string.
 /// </summary>
-public static class Keeper
+public static partial class StringExtensions
 {
     /// <summary>
     /// Uses a regular expression to return a new string containing all occurrences of all unicode digits (in any script) in the current instance.

--- a/IvanStoychev.Useful.String.Extensions/Remover.cs
+++ b/IvanStoychev.Useful.String.Extensions/Remover.cs
@@ -9,7 +9,7 @@ namespace IvanStoychev.Useful.String.Extensions;
 /// <summary>
 /// Contains methods that remove substrings.
 /// </summary>
-public static class Remover
+public static partial class StringExtensions
 {
     /// <summary>
     /// Returns a new string in which all occurrences of the given <paramref name="removeString"/> in the current instance are replaced with <see cref="string.Empty"/>.

--- a/IvanStoychev.Useful.String.Extensions/Replacer.cs
+++ b/IvanStoychev.Useful.String.Extensions/Replacer.cs
@@ -7,7 +7,7 @@ namespace IvanStoychev.Useful.String.Extensions;
 /// <summary>
 /// Contains methods that replace given substrings with a new, specified string.
 /// </summary>
-public static class Replacer
+public static partial class StringExtensions
 {
     /// <summary>
     /// Returns a new string in which all occurrences of all members of <paramref name="oldStrings"/>

--- a/IvanStoychev.Useful.String.Extensions/Selector.cs
+++ b/IvanStoychev.Useful.String.Extensions/Selector.cs
@@ -6,7 +6,7 @@ namespace IvanStoychev.Useful.String.Extensions;
 /// <summary>
 /// Contains methods that select substrings and charaters from strings.
 /// </summary>
-public static class Selector
+public static partial class StringExtensions
 {
     /// <summary>
     /// Retrieves the substring from the start of this instance to the first occurrence of the given <paramref name="endString"/>.


### PR DESCRIPTION
- Fixed some test names, test data and added missing tests for "TrimStart" and "TrimEnd" methods.
- Updated library to .Net 8.
- Changed library class structure to additionally facilitate users. Now all classes are partial and named "StringExtensions" to allow users to have their own classes using the old class names. File names remain unchanged for ease of structural navigation.